### PR TITLE
Handle Imagestream sub resources whiteout in OpenshiftPlugin by default

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -136,6 +136,12 @@ func Run(request transform.PluginRequest) (transform.PluginResponse, error) {
 	case "Build":
 		logger.Info("found build, adding to whiteout")
 		whiteOut = true
+	case "ImageStreamTag":
+		logger.Info("found ImageStreamTag sub-resource, adding to whiteout")
+		whiteOut = true
+	case "ImageTag":
+		logger.Info("found ImageTag sub-resource, adding to whiteout")
+		whiteOut = true
 	case "BuildConfig":
 		logger.Info("found build config, processing")
 		patch, err = UpdateBuildConfig(u, inputFields)


### PR DESCRIPTION
# PR: OpenShiftPlugin should whiteout ImageStreamTag and ImageTag sub-resources

  Fixes [#490](https://github.com/migtools/crane/issues/490). When migrating apps with ImageStreams, `ImageStreamTag` and `ImageTag` resources were included in the final output alongside the `ImageStream` itself, causing apply failures on the target cluster.

  ## The Problem

  ```bash
  kubectl apply -f output.yaml
  # ImageStream created successfully ✅
  # OCP auto-creates ImageStreamTag and ImageTag from spec.tags
  # Then kubectl tries to apply the migrated ones:
  # Error: imagestreamtag.image.openshift.io "internal-alpine:int" already exists ❌
  # Error: ImageTag.image.openshift.io "internal-alpine:int" is invalid: may not update fields ❌
 ```

  ImageStreamTag and ImageTag are sub-resources — OCP auto-creates them when an ImageStream is applied. Migrating them separately causes conflicts.

 ## The Fix

  Added ImageStreamTag and ImageTag to the OpenShiftPlugin's whiteout logic in cmd.go, following the same pattern used for Build, builder ServiceAccounts, and copied CSVs.

  case "ImageStreamTag":
      logger.Info("found ImageStreamTag sub-resource, adding to whiteout")
      whiteOut = true
  case "ImageTag":
      logger.Info("found ImageTag sub-resource, adding to whiteout")
      whiteOut = true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization handling for image-related sub-resources to properly recognize them as excluded from certain authorization contexts, consistent with existing behavior for build resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->