### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,71 +4,69 @@ on:
     inputs:
       version:
         description: Bump Version
-        default: v0.0.1
+        default: v0.1.0
         required: true
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.16
+          go-version: "1.25.0"
 
       - name: Check out source code
-        uses: actions/checkout@v2
-        with:
-          path: main
-          ref: ${{ github.event.pull_request.head.sha }}
+        uses: actions/checkout@v4
 
       - name: Tidy
         env:
           GOPROXY: "https://proxy.golang.org"
-        run: cd main && go mod tidy && git diff --quiet HEAD
+        run: go mod tidy && git diff --quiet HEAD
 
       - name: Build openshift plugin linux amd64
         env:
           GOPROXY: "https://proxy.golang.org"
-        run: cd main/ && GOOS=linux GOARCH=amd64 go build -o ~/main/bin/amd64-linux-openshiftplugin-${{ github.event.inputs.version }} .
+        run: GOOS=linux GOARCH=amd64 go build -o bin/amd64-linux-openshiftplugin-${{ github.event.inputs.version }} .
 
       - name: Build openshift plugin darwin amd64
         env:
           GOPROXY: "https://proxy.golang.org"
-        run: cd main/ && GOOS=darwin GOARCH=amd64 go build -o ~/main/bin/amd64-darwin-openshiftplugin-${{ github.event.inputs.version }} .
+        run: GOOS=darwin GOARCH=amd64 go build -o bin/amd64-darwin-openshiftplugin-${{ github.event.inputs.version }} .
 
       - name: Build openshift plugin darwin arm64
         env:
           GOPROXY: "https://proxy.golang.org"
-        run: cd main/ && GOOS=darwin GOARCH=arm64 go build -o ~/main/bin/arm64-darwin-openshiftplugin-${{ github.event.inputs.version }} .
+        run: GOOS=darwin GOARCH=arm64 go build -o bin/arm64-darwin-openshiftplugin-${{ github.event.inputs.version }} .
 
       - name: release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "~/main/bin/*"
+          artifacts: "bin/*"
+          allowUpdates: true
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.inputs.version }}
 
       - name: Checkout crane-plugins
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/crane-plugins
           token: ${{ secrets.PLUGIN_RELEASE }}
           path: crane-plugins
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.12"
 
       - name: Updating index file and adding manifest
         shell: bash
         run: |
           pip install pyyaml
           cd crane-plugins
-          python ~/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/main/.github/workflows/script.py "${{ github.event.inputs.version }}" "${{ github.repository_owner }}" "${{ github.repository }}"
-     
+          python $GITHUB_WORKSPACE/.github/workflows/script.py "${{ github.event.inputs.version }}" "${{ github.repository_owner }}" "${{ github.repository }}"
+
       - name: Create Pull Request against crane-plugins
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.PLUGIN_RELEASE }}
           commit-message: Updating index and adding manifest from openshift plugin release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,16 @@ jobs:
 
       - name: Check out source code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Tidy
         env:
           GOPROXY: "https://proxy.golang.org"
         run: go mod tidy && git diff --quiet HEAD
+
+      - name: Ensure artifact directory exists
+        run: mkdir -p bin
 
       - name: Build openshift plugin linux amd64
         env:


### PR DESCRIPTION
# PR: Update release workflow for Go 1.25 and refactored project layout

  The release workflow was broken after the plugin refactor — it used Go 1.16 (incompatible with `go 1.25.0` in go.mod) and outdated GitHub Actions versions.

  ## What changed
  
  | Setting | Before | After |
  |---------|--------|-------|
  | Go version | 1.16 | 1.25.0 |
  | actions/setup-go | v2 | v5 |
  | actions/checkout | v2 | v4 |
  | actions/setup-python | v2 (Python 3.8) | v5 (Python 3.12) |
  | create-pull-request | v3 | v6 |
  | ncipollo/release-action | v1 | v1 + `allowUpdates: true` |
  | Default version | v0.0.1 | v0.1.0 |
  | Checkout path | `path: main` subdirectory | Root (simpler) |
  | Build command | `cd main/ && go build .` | `go build .` |
  | Binary output | `~/main/bin/` | `bin/` |

  ## Why

  - Go 1.16 can't build the module after `go.mod` was updated to `go 1.25.0`
  - `allowUpdates: true` lets the workflow upload binaries to the existing v0.1.0 release
  - Simplified checkout removes the unnecessary `path: main` indirection

  ## Files Changed

  | File | Change |
  |------|--------|
  | `.github/workflows/release.yml` | Updated Go version, Actions versions, simplified paths |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions release workflow with newer versions of Go toolchain, Python, and CI/CD action dependencies to enhance build reliability and platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->